### PR TITLE
Fixed the unicode art for the tree.

### DIFF
--- a/images.go
+++ b/images.go
@@ -106,9 +106,9 @@ func WalkTree(buffer *bytes.Buffer, noTrunc bool, images []Image, byParent map[s
 					WalkTree(buffer, noTrunc, subimages, byParent, prefix+"  ")
 				}
 			} else {
-				PrintTreeNode(buffer, noTrunc, image, prefix+"|─")
+				PrintTreeNode(buffer, noTrunc, image, prefix+"├─")
 				if subimages, exists := byParent[image.Id]; exists {
-					WalkTree(buffer, noTrunc, subimages, byParent, prefix+"| ")
+					WalkTree(buffer, noTrunc, subimages, byParent, prefix+"│ ")
 				}
 			}
 		}


### PR DESCRIPTION
The lines were not connected and it triggered in me an OCD impulse to
make this PR :).

Now it looks like this:

│   └─b51d52a11aaa Virtual Size: 0.0 B
│     └─60ad43e4527d Virtual Size: 118.1 MB
│       ├─120524f147a2 Virtual Size: 118.1 MB
│       │ └─8cb31f8566ea Virtual Size: 118.1 MB
│       │   └─0f9e851b2af9 Virtual Size: 147.9 MB

Instead of that:

| └─07302703becc Virtual Size: 101.2 MB
|   └─cf8dc907452c Virtual Size: 101.2 MB
|     └─a7cf8ae4e998 Virtual Size: 171.3 MB Tags: ubuntu:12.10,
|       |─e18d8001204e Virtual Size: 171.3 MB
