### PR TITLE
Direct client access

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
-# dockviz
+# dockviz: Visualizing Docker Data
 
-Visualizing Docker Data
+This command takes Docker image and container information and presents in
+different ways, to help you understand what's going on inside the system.
 
-This command takes the raw Docker JSON and visualizes it in various ways.
+# Quick Start
 
-For image information, output can be formatted as
-[Graphviz](http://www.graphviz.org), as a tree in the terminal, or in a short summary.
+1. Download the [latest release](https://github.com/justone/dockviz/releases).
+2. Visualize images by running `dockviz images -t`, which has similar output to `docker images -t`.
 
-For container information, only Graphviz output has been implemented.
+Image can be visualized as [Graphviz](http://www.graphviz.org), or as a tree or short summary in the terminal.  Only Graphviz output has been implemented for containers.
 
-# Examples
+# Output Examples
 
 ## Containers
 
 Currently, containers are visualized with labeled lines for links.  Containers that aren't running are greyed out.
+
+```
+$ dockviz containers -d | dot -Tpng -o containers.png
+```
 
 ![](sample/containers.png "Container")
 
@@ -21,11 +26,16 @@ Currently, containers are visualized with labeled lines for links.  Containers t
 
 Image info is visualized with lines indicating parent images:
 
+```
+$ dockviz images -d | dot -Tpng -o images.png
+```
+
 ![](sample/images.png "Image")
 
 Or in short form:
 
 ```
+$ dockviz images -s
 nate/mongodb: latest
 redis: latest
 ubuntu: 12.04, precise, 12.10, quantal, 13.04, raring
@@ -34,6 +44,7 @@ ubuntu: 12.04, precise, 12.10, quantal, 13.04, raring
 Or as a tree in the terminal:
 
 ```
+$ dockviz images -t
 └─511136ea3c5a Virtual Size: 0.0 B
   |─f10ebce2c0e1 Virtual Size: 103.7 MB
   | └─82cdea7ab5b5 Virtual Size: 103.9 MB
@@ -67,29 +78,21 @@ Or as a tree in the terminal:
 
 # Running
 
-## TCP
+Dockviz supports connecting to the Docker daemon directly.  It defaults to `unix:///var/run/docker.sock`, but respects the following as well:
 
-When docker is listening on the TCP port:
+* The `DOCKER_HOST`, `DOCKER_CERT_PATH`, and `DOCKER_TLS_VERIFY` environment variables, as set up by [boot2docker](http://boot2docker.io/) or [docker-machine](https://docs.docker.com/machine/).
+* Command line arguments (e.g. `--tlscacert`), like those that Docker itself supports.
+
+Dockviz also supports receiving Docker image or container json data on standard input.
 
 ```
 $ curl -s http://localhost:4243/images/json?all=1 | dockviz images --tree
 $ curl -s http://localhost:4243/containers/json?all=1 | dockviz containers --dot | dot -Tpng -o containers.png
-```
-
-## Socket
-
-When docker is listening on the socket:
-
-```
 $ echo -e "GET /images/json?all=1 HTTP/1.0\r\n" | nc -U /var/run/docker.sock | tail -n +5 | dockviz images --tree
 $ echo -e "GET /containers/json?all=1 HTTP/1.0\r\n" | nc -U /var/run/docker.sock | tail -n +5 | dockviz containers --dot | dot -Tpng -o containers.png
 ```
 
-GNU netcat doesn't support `-U` (UNIX socket) flag, so OpenBSD variant can be used.
-
-## Direct from Docker
-
-Someday soon the Docker command line will allow dumping the image and container JSON directly.
+Note: GNU netcat doesn't support `-U` (UNIX socket) flag, so OpenBSD variant can be used.
 
 # Binaries
 
@@ -101,4 +104,3 @@ See the [releases](https://github.com/justone/dockviz/releases) area for binarie
 go get ./...
 go build
 ```
-

--- a/cli.go
+++ b/cli.go
@@ -11,6 +11,7 @@ type GlobalOptions struct {
 	TLSCert   string `long:"tlscert" value-name:"~/.docker/cert.pem" description:"Path to TLS certificate file"`
 	TLSKey    string `long:"tlskey" value-name:"~/.docker/key.pem" description:"Path to TLS key file"`
 	TLSVerify bool   `long:"tlsverify" description:"Use TLS and verify the remote"`
+	Host      string `long:"host" short:"H" value-name:"unix:///var/run/docker.sock" description:"Docker host to connect to"`
 }
 
 var globalOptions GlobalOptions

--- a/cli.go
+++ b/cli.go
@@ -7,7 +7,10 @@ import (
 )
 
 type GlobalOptions struct {
-	// no options yet
+	TLSCaCert string `long:"tlscacert" value-name:"~/.docker/ca.pem" description:"Trust certs signed only by this CA"`
+	TLSCert   string `long:"tlscert" value-name:"~/.docker/cert.pem" description:"Path to TLS certificate file"`
+	TLSKey    string `long:"tlskey" value-name:"~/.docker/key.pem" description:"Path to TLS key file"`
+	TLSVerify bool   `long:"tlsverify" description:"Use TLS and verify the remote"`
 }
 
 var globalOptions GlobalOptions

--- a/cli.go
+++ b/cli.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/jessevdk/go-flags"
@@ -12,12 +13,19 @@ type GlobalOptions struct {
 	TLSKey    string `long:"tlskey" value-name:"~/.docker/key.pem" description:"Path to TLS key file"`
 	TLSVerify bool   `long:"tlsverify" description:"Use TLS and verify the remote"`
 	Host      string `long:"host" short:"H" value-name:"unix:///var/run/docker.sock" description:"Docker host to connect to"`
+	Version   func() `long:"version" short:"v" description:"Display version information."`
 }
 
 var globalOptions GlobalOptions
 var parser = flags.NewParser(&globalOptions, flags.Default)
 
+var version = "v0.2"
+
 func main() {
+	globalOptions.Version = func() {
+		fmt.Println("dockviz", version)
+		os.Exit(0)
+	}
 	if _, err := parser.Parse(); err != nil {
 		os.Exit(1)
 	}

--- a/containers.go
+++ b/containers.go
@@ -51,6 +51,9 @@ func (x *ContainersCommand) Execute(args []string) error {
 	} else {
 
 		client, err := connect()
+		if err != nil {
+			return err
+		}
 
 		clientContainers, err := client.ListContainers(docker.ListContainersOptions{All: true})
 		if err != nil {

--- a/containers.go
+++ b/containers.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/fsouza/go-dockerclient"
+
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -28,15 +30,47 @@ var containersCommand ContainersCommand
 
 func (x *ContainersCommand) Execute(args []string) error {
 
-	// read in stdin
-	stdin, err := ioutil.ReadAll(os.Stdin)
+	var containers *[]Container
+
+	stat, err := os.Stdin.Stat()
 	if err != nil {
-		return fmt.Errorf("error reading all input", err)
+		return fmt.Errorf("error reading stdin stat", err)
 	}
 
-	containers, err := parseContainersJSON(stdin)
-	if err != nil {
-		return err
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		// read in stdin
+		stdin, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("error reading all input", err)
+		}
+
+		containers, err = parseContainersJSON(stdin)
+		if err != nil {
+			return err
+		}
+	} else {
+
+		client, err := connect()
+
+		clientContainers, err := client.ListContainers(docker.ListContainersOptions{All: true})
+		if err != nil {
+			return err
+		}
+
+		var conts []Container
+		for _, container := range clientContainers {
+			conts = append(conts, Container{
+				container.ID,
+				container.Image,
+				container.Names,
+				apiPortToMap(container.Ports),
+				container.Created,
+				container.Status,
+				container.Command,
+			})
+		}
+
+		containers = &conts
 	}
 
 	if containersCommand.Dot {
@@ -46,6 +80,20 @@ func (x *ContainersCommand) Execute(args []string) error {
 	}
 
 	return nil
+}
+
+func apiPortToMap(ports []docker.APIPort) []map[string]interface{} {
+	result := make([]map[string]interface{}, 2)
+	for _, port := range ports {
+		intPort := map[string]interface{}{
+			"IP":          port.IP,
+			"Type":        port.Type,
+			"PrivatePort": port.PrivatePort,
+			"PublicPort":  port.PublicPort,
+		}
+		result = append(result, intPort)
+	}
+	return result
 }
 
 func parseContainersJSON(rawJSON []byte) (*[]Container, error) {

--- a/images.go
+++ b/images.go
@@ -53,6 +53,9 @@ func (x *ImagesCommand) Execute(args []string) error {
 	} else {
 
 		client, err := connect()
+		if err != nil {
+			return err
+		}
 
 		clientImages, err := client.ListImages(docker.ListImagesOptions{All: true})
 		if err != nil {

--- a/images.go
+++ b/images.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"github.com/fsouza/go-dockerclient"
+
 	"bytes"
 	"encoding/json"
 	"fmt"
@@ -29,15 +31,52 @@ var imagesCommand ImagesCommand
 
 func (x *ImagesCommand) Execute(args []string) error {
 
-	// read in stdin
-	stdin, err := ioutil.ReadAll(os.Stdin)
+	var images *[]Image
+
+	stat, err := os.Stdin.Stat()
 	if err != nil {
-		return fmt.Errorf("error reading all input", err)
+		return fmt.Errorf("error reading stdin stat", err)
 	}
 
-	images, err := parseImagesJSON(stdin)
-	if err != nil {
-		return err
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		// read in stdin
+		stdin, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("error reading all input", err)
+		}
+
+		images, err = parseImagesJSON(stdin)
+		if err != nil {
+			return err
+		}
+
+	} else {
+
+		// grab directly from docker daemon
+		client, err := docker.NewClient("unix:///var/run/docker.sock")
+		if err != nil {
+			return err
+		}
+
+		clientImages, err := client.ListImages(docker.ListImagesOptions{All: true})
+		if err != nil {
+			return err
+		}
+
+		var ims []Image
+		for _, image := range clientImages {
+			// fmt.Println(image)
+			ims = append(ims, Image{
+				image.ID,
+				image.ParentID,
+				image.RepoTags,
+				image.VirtualSize,
+				image.Size,
+				image.Created,
+			})
+		}
+
+		images = &ims
 	}
 
 	if imagesCommand.Dot {

--- a/images.go
+++ b/images.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"strings"
 )
 
@@ -53,27 +52,7 @@ func (x *ImagesCommand) Execute(args []string) error {
 
 	} else {
 
-		// grab directly from docker daemon
-		endpoint := os.Getenv("DOCKER_HOST")
-		if len(endpoint) == 0 {
-			endpoint = "unix:///var/run/docker.sock"
-		}
-
-		var client *docker.Client
-		if dockerCertPath := os.Getenv("DOCKER_CERT_PATH"); len(dockerCertPath) > 0 {
-			cert := path.Join(dockerCertPath, "cert.pem")
-			key := path.Join(dockerCertPath, "key.pem")
-			ca := path.Join(dockerCertPath, "ca.pem")
-			client, err = docker.NewTLSClient(endpoint, cert, key, ca)
-			if err != nil {
-				return err
-			}
-		} else {
-			client, err = docker.NewClient(endpoint)
-			if err != nil {
-				return err
-			}
-		}
+		client, err := connect()
 
 		clientImages, err := client.ListImages(docker.ListImagesOptions{All: true})
 		if err != nil {

--- a/util.go
+++ b/util.go
@@ -11,8 +11,13 @@ import (
 func connect() (*docker.Client, error) {
 
 	// grab directly from docker daemon
-	endpoint := os.Getenv("DOCKER_HOST")
-	if len(endpoint) == 0 {
+	var endpoint string
+	if env_endpoint := os.Getenv("DOCKER_HOST"); len(env_endpoint) > 0 {
+		endpoint = env_endpoint
+	} else if len(globalOptions.Host) > 0 {
+		endpoint = globalOptions.Host
+	} else {
+		// assume local socket
 		endpoint = "unix:///var/run/docker.sock"
 	}
 

--- a/util.go
+++ b/util.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/fsouza/go-dockerclient"
-
+	"errors"
 	"os"
 	"path"
+
+	"github.com/fsouza/go-dockerclient"
 )
 
 func connect() (*docker.Client, error) {
@@ -17,13 +18,23 @@ func connect() (*docker.Client, error) {
 
 	var client *docker.Client
 	var err error
-	if dockerCertPath := os.Getenv("DOCKER_CERT_PATH"); len(dockerCertPath) > 0 {
-		cert := path.Join(dockerCertPath, "cert.pem")
-		key := path.Join(dockerCertPath, "key.pem")
-		ca := path.Join(dockerCertPath, "ca.pem")
-		client, err = docker.NewTLSClient(endpoint, cert, key, ca)
-		if err != nil {
-			return nil, err
+	dockerTlsVerifyEnv := os.Getenv("DOCKER_TLS_VERIFY")
+	if dockerTlsVerifyEnv == "1" || globalOptions.TLSVerify {
+		if dockerCertPath := os.Getenv("DOCKER_CERT_PATH"); len(dockerCertPath) > 0 {
+			cert := path.Join(dockerCertPath, "cert.pem")
+			key := path.Join(dockerCertPath, "key.pem")
+			ca := path.Join(dockerCertPath, "ca.pem")
+			client, err = docker.NewTLSClient(endpoint, cert, key, ca)
+			if err != nil {
+				return nil, err
+			}
+		} else if len(globalOptions.TLSCert) > 0 && len(globalOptions.TLSKey) > 0 && len(globalOptions.TLSCaCert) > 0 {
+			client, err = docker.NewTLSClient(endpoint, globalOptions.TLSCert, globalOptions.TLSKey, globalOptions.TLSCaCert)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, errors.New("TLS Verification requested but certs not specified")
 		}
 	} else {
 		client, err = docker.NewClient(endpoint)

--- a/util.go
+++ b/util.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"github.com/fsouza/go-dockerclient"
+
+	"os"
+	"path"
+)
+
+func connect() (*docker.Client, error) {
+
+	// grab directly from docker daemon
+	endpoint := os.Getenv("DOCKER_HOST")
+	if len(endpoint) == 0 {
+		endpoint = "unix:///var/run/docker.sock"
+	}
+
+	var client *docker.Client
+	var err error
+	if dockerCertPath := os.Getenv("DOCKER_CERT_PATH"); len(dockerCertPath) > 0 {
+		cert := path.Join(dockerCertPath, "cert.pem")
+		key := path.Join(dockerCertPath, "key.pem")
+		ca := path.Join(dockerCertPath, "ca.pem")
+		client, err = docker.NewTLSClient(endpoint, cert, key, ca)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		client, err = docker.NewClient(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return client, nil
+}


### PR DESCRIPTION
Dockviz is nifty and all, but it should really connect to docker itself.  That would save the trouble of long command lines or shell aliases.

Progress:
* [x] images
* [x] containers
* [x] any refactoring needed
* [x] documentation
