### PR TITLE
Fix crash tickled by supplying partial image id.

### DIFF
--- a/images.go
+++ b/images.go
@@ -101,7 +101,7 @@ func (x *ImagesCommand) Execute(args []string) error {
 			for _, image := range *images {
 				// check if the start image arg matches an image id
 				if strings.Index(image.Id, startImageArg) == 0 {
-					startImage = startImageArg
+					startImage = image.Id
 					break IMAGES
 				}
 


### PR DESCRIPTION
```
$ docker images
REPOSITORY           TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
mynotebook           latest              af94c43071c9        8 days ago          742.2 MB
<none>               <none>              b1de6d9fefca        8 days ago          742.2 MB
<none>               <none>              d5e0f2c7ddf4        8 days ago          742.2 MB
ipython/ipython      3.x                 875400ef772c        11 days ago         742.2 MB
ipython/notebook     latest              15436702760f        11 days ago         742.3 MB
ipython/scipystack   latest              720dc652b731        2 weeks ago         2.857 GB
training/webapp      latest              02a8815912ca        12 weeks ago        348.8 MB

$ ./dockviz images --tree 15436702760f
└─15436702760f Virtual Size: 742.3 MB Tags: ipython/notebook:latest

$ ./dockviz images --tree 15
└─15436702760f Virtual Size: 742.3 MB Tags: ipython/notebook:latest
```
