### PR TITLE
Fix --only-labelled flag in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ dockviz images --dot | dot -Tpng -o images.png
 ```
 $ dockviz images -d -l | dot -Tpng -o images.png
 OR
-$ dockviz images --dot -only-labelled | dot -Tpng -o images.png
+$ dockviz images --dot --only-labelled | dot -Tpng -o images.png
 ```
 
 ![](sample/images_only_labelled.png "Image")


### PR DESCRIPTION
Before (without #19 applied, no output piped to `dot`):

```sh-session
$ alias dockviz="docker run --rm -v /var/run/docker.sock:/var/run/docker.sock nate/dockviz"
$ dockviz images --dot -only-labelled | dot -Tpng -o images.png && ls images.png
ls: images.png: No such file or directory
```

Before (with #19 applied, error piped to `dot`):

```sh-session
$ alias dockviz="docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock nate/dockviz"
$ dockviz images --dot -only-labelled | dot -Tpng -o images.png && ls images.png
Error: <stdin>: syntax error in line 1 near 'unknown'
```

After:

```sh-session
$ dockviz images --dot --only-labelled | dot -Tpng -o images.png && ls images.png
images.png
```