### PR TITLE
Make alias show output

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ different ways, to help you understand what's going on inside the system.
   * Set up an alias to run it from the (5.8 MB) docker image: 
 
   ```
-  alias dockviz="docker run --rm -v /var/run/docker.sock:/var/run/docker.sock nate/dockviz"
+  alias dockviz="docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock nate/dockviz"
   ```
 2. Visualize images by running `dockviz images -t`, which has similar output to `docker images -t`.
 


### PR DESCRIPTION
Before:

```sh-session
$ alias dockviz="docker run --rm -v /var/run/docker.sock:/var/run/docker.sock nate/dockviz"
$ dockviz --help
```

After:

```sh-session
$ alias dockviz="docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock nate/dockviz"
$ dockviz --help
Usage:
  dockviz [OPTIONS] <containers | help | images>

Application Options:
      --tlscacert=~/.docker/ca.pem          Trust certs signed only by this CA
      --tlscert=~/.docker/cert.pem          Path to TLS certificate file
      --tlskey=~/.docker/key.pem            Path to TLS key file
      --tlsverify                           Use TLS and verify the remote
  -H, --host=unix:///var/run/docker.sock    Docker host to connect to
  -v, --version                             Display version information.

Help Options:
  -h, --help                                Show this help message

Available commands:
  containers  Visualize docker containers.
  help        Help for dockviz.
  images      Visualize docker images.
```
