### PR TITLE
enhancements for newer docker versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ Image info is visualized with lines indicating parent images:
 
 ```
 $ dockviz images -d | dot -Tpng -o images.png
-OR
-$ dockviz images --dot | dot -Tpng -o images.png
 ```
 
 ![](sample/images.png "Image")

--- a/README.md
+++ b/README.md
@@ -243,4 +243,3 @@ docker push nate/dockviz
 
 
 
-

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Image can be visualized as [Graphviz](http://www.graphviz.org), or as a tree or 
 Currently, containers are visualized with labelled lines for links.  Containers that aren't running are greyed out.
 
 ```
+# show all containers
 $ dockviz containers -d | dot -Tpng -o containers.png
 
 # only show running containers

--- a/README.md
+++ b/README.md
@@ -12,7 +12,12 @@ different ways, to help you understand what's going on inside the system.
   * Set up an alias to run it from the (5.8 MB) docker image: 
 
   ```
+  # if docker client using local unix socket
   alias dockviz="docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock nate/dockviz"
+
+  # if docker client using tcp
+  alias dockviz="docker run -it --rm -e DOCKER_HOST='tcp://127.0.0.1:2375' nate/dockviz"
+
   ```
 2. Visualize images by running `dockviz images -t`, which has similar output to `docker images -t`.
 
@@ -188,7 +193,6 @@ $ dockviz images -t -i -c
 Dockviz supports connecting to the Docker daemon directly.  It defaults to `unix:///var/run/docker.sock`, but respects the following as well:
 
 * The `DOCKER_HOST`, `DOCKER_CERT_PATH`, and `DOCKER_TLS_VERIFY` environment variables, as set up by [boot2docker](http://boot2docker.io/) or [docker-machine](https://docs.docker.com/machine/).
-  * For example: docker run -e DOCKER_HOST='tcp://127.0.0.1:2375' nate/dockviz
 
 * Command line arguments (e.g. `--tlscacert`), like those that Docker itself supports.
 

--- a/README.md
+++ b/README.md
@@ -216,8 +216,31 @@ See the [releases](https://github.com/justone/dockviz/releases) area for binarie
 # Build
 
 ```bash
-# force static compilation
+# install graphviz in host environment for rendering (Debian example)
+sudo apt-get install git graphviz -y
+
+# pull latest code
+cd $GOPATH
+git clone https://github.com/fabianlee/dockviz.git
+
+# force static compilation for go language
 export CGO_ENABLED=0
+
+# build go program
+cd dockviz
 go get
-go build
+go build -a
+
+# build docker image
+docker build --no-cache=true -t "fabianlee/dockviz:1.0" -t "fabianlee/dockviz:latest" .
+
+# push to docker hub
+docker login --username=fabianlee --password=xxxxxxx
+docker push fabianlee/dockviz
+
 ```
+
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ different ways, to help you understand what's going on inside the system.
   ```
 2. Visualize images by running `dockviz images -t`, which has similar output to `docker images -t`.
 
-Image can be visualized as [Graphviz](http://www.graphviz.org), or as a tree or short summary in the terminal.  Only Graphviz output has been implemented for containers.
+Image can be visualized as [Graphviz](http://www.graphviz.org), or as a tree or short summary in the terminal.  Only Graphviz output has been implemented for containers (Debian: apt-get install graphviz).
 
 # Output Examples
 
@@ -26,6 +26,9 @@ Currently, containers are visualized with labelled lines for links.  Containers 
 
 ```
 $ dockviz containers -d | dot -Tpng -o containers.png
+
+# only show running containers
+$ dockviz containers -d -r | dot -Tpng -o containers.png
 ```
 
 ![](sample/containers.png "Container")

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ sudo apt-get install git graphviz -y
 
 # pull latest code
 cd $GOPATH
-git clone https://github.com/fabianlee/dockviz.git
+git clone https://github.com/nate/dockviz.git
 
 # force static compilation for go language
 export CGO_ENABLED=0
@@ -232,11 +232,11 @@ go get
 go build -a
 
 # build docker image
-docker build --no-cache=true -t "fabianlee/dockviz:1.0" -t "fabianlee/dockviz:latest" .
+docker build --no-cache=true -t "nate/dockviz:1.0" -t "nate/dockviz:latest" .
 
 # push to docker hub
-docker login --username=fabianlee --password=xxxxxxx
-docker push fabianlee/dockviz
+docker login --username=mygituser --password=xxxxxxx
+docker push nate/dockviz
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ $ dockviz images -t -i -c
 Dockviz supports connecting to the Docker daemon directly.  It defaults to `unix:///var/run/docker.sock`, but respects the following as well:
 
 * The `DOCKER_HOST`, `DOCKER_CERT_PATH`, and `DOCKER_TLS_VERIFY` environment variables, as set up by [boot2docker](http://boot2docker.io/) or [docker-machine](https://docs.docker.com/machine/).
+  * For example: docker run -e DOCKER_HOST='tcp://127.0.0.1:2375' nate/dockviz
+
 * Command line arguments (e.g. `--tlscacert`), like those that Docker itself supports.
 
 Dockviz also supports receiving Docker image or container json data on standard input.
@@ -206,6 +208,8 @@ See the [releases](https://github.com/justone/dockviz/releases) area for binarie
 # Build
 
 ```bash
-go get ./...
+# force static compilation
+export CGO_ENABLED=0
+go get
 go build
 ```

--- a/cli.go
+++ b/cli.go
@@ -1,4 +1,4 @@
-package main // import "github.com/justone/dockviz"
+package main
 
 import (
 	"fmt"

--- a/containers.go
+++ b/containers.go
@@ -24,7 +24,7 @@ type Container struct {
 type ContainersCommand struct {
 	Dot        bool `short:"d" long:"dot" description:"Show container information as Graphviz dot."`
 	NoTruncate bool `short:"n" long:"no-trunc" description:"Don't truncate the container IDs."`
-	//OnlyRunning bool `short:"r" long:"running" description:"Only show running containers, not Exited"`
+	OnlyRunning bool `short:"r" long:"running" description:"Only show running containers, not Exited"`
 }
 
 var containersCommand ContainersCommand
@@ -82,8 +82,7 @@ func (x *ContainersCommand) Execute(args []string) error {
 	}
 
 	if containersCommand.Dot {
-		//fmt.Printf(jsonContainersToDot(containers, containersCommand.OnlyRunning))
-		fmt.Printf(jsonContainersToDot(containers, true))
+		fmt.Printf(jsonContainersToDot(containers, containersCommand.OnlyRunning))
 	} else {
 		return fmt.Errorf("Please specify --dot")
 	}
@@ -140,7 +139,7 @@ func jsonContainersToDot(containers *[]Container,OnlyRunning bool) string {
 	LinkMap = make(map[string]string)
 
 	for _, container := range *containers {
-		//if OnlyRunning && strings.HasPrefix(container.Status,"Exit") { continue }
+		if OnlyRunning && strings.HasPrefix(container.Status,"Exit") { continue }
 
 		var containerName string
 

--- a/containers.go
+++ b/containers.go
@@ -123,12 +123,13 @@ func jsonContainersToDot(containers *[]Container,OnlyRunning bool) string {
 	buffer.WriteString("digraph docker {\n")
 
 	// build list of all primary container names
+	// this is so we can throw away links to 
+	// non-primary container name
 	var PrimaryContainerNames map[string]string
 	PrimaryContainerNames = make(map[string]string)
 	for _, container := range *containers {
 		for _, name := range container.Names {
 			if strings.Count(name, "/") == 1 {
-				//fmt.Printf("%s\n",name[1:])
 				PrimaryContainerNames[name[1:]] = name[1:]
 			}
 		}
@@ -154,7 +155,10 @@ func jsonContainersToDot(containers *[]Container,OnlyRunning bool) string {
 			nameParts := strings.Split(name, "/")
 			if len(nameParts) > 2 {
 				//fmt.Printf("\t%s to %s\n",containerName,nameParts[1])
+				// source and dest should be primary container names
 				if IsPrimaryContainerName(containerName,PrimaryContainerNames) && IsPrimaryContainerName(nameParts[1],PrimaryContainerNames) {
+
+				   // only create link if none exists already
 				   if _,ok := LinkMap[containerName + "-" + nameParts[1]]; !ok {
 				    LinkMap[containerName + "-" + nameParts[1]] = "exists"
 				    buffer.WriteString(fmt.Sprintf(" \"%s\" -> \"%s\" [label = \" %s\" ]\n", containerName, nameParts[1], nameParts[len(nameParts)-1] ))

--- a/containers.go
+++ b/containers.go
@@ -24,6 +24,7 @@ type Container struct {
 type ContainersCommand struct {
 	Dot        bool `short:"d" long:"dot" description:"Show container information as Graphviz dot."`
 	NoTruncate bool `short:"n" long:"no-trunc" description:"Don't truncate the container IDs."`
+	//OnlyRunning bool `short:"r" long:"running" description:"Only show running containers, not Exited"`
 }
 
 var containersCommand ContainersCommand
@@ -81,7 +82,8 @@ func (x *ContainersCommand) Execute(args []string) error {
 	}
 
 	if containersCommand.Dot {
-		fmt.Printf(jsonContainersToDot(containers))
+		//fmt.Printf(jsonContainersToDot(containers, containersCommand.OnlyRunning))
+		fmt.Printf(jsonContainersToDot(containers, true))
 	} else {
 		return fmt.Errorf("Please specify --dot")
 	}
@@ -115,24 +117,49 @@ func parseContainersJSON(rawJSON []byte) (*[]Container, error) {
 	return &containers, nil
 }
 
-func jsonContainersToDot(containers *[]Container) string {
+func jsonContainersToDot(containers *[]Container,OnlyRunning bool) string {
 
 	var buffer bytes.Buffer
 	buffer.WriteString("digraph docker {\n")
 
+	// build list of all primary container names
+	var PrimaryContainerNames map[string]string
+	PrimaryContainerNames = make(map[string]string)
 	for _, container := range *containers {
+		for _, name := range container.Names {
+			if strings.Count(name, "/") == 1 {
+				//fmt.Printf("%s\n",name[1:])
+				PrimaryContainerNames[name[1:]] = name[1:]
+			}
+		}
+	}
+
+	// stores ony first value of link to avoid duplicates
+	var LinkMap map[string]string
+	LinkMap = make(map[string]string)
+
+	for _, container := range *containers {
+		//if OnlyRunning && strings.HasPrefix(container.Status,"Exit") { continue }
 
 		var containerName string
 
+		//fmt.Printf("container status/Names %s/%s\n",container.Status,container.Names)
 		for _, name := range container.Names {
 			if strings.Count(name, "/") == 1 {
 				containerName = name[1:]
 			}
 		}
+	
 		for _, name := range container.Names {
 			nameParts := strings.Split(name, "/")
 			if len(nameParts) > 2 {
-				buffer.WriteString(fmt.Sprintf(" \"%s\" -> \"%s\" [label = \" %s\" ]\n", containerName, nameParts[1], nameParts[len(nameParts)-1]))
+				//fmt.Printf("\t%s to %s\n",containerName,nameParts[1])
+				if IsPrimaryContainerName(containerName,PrimaryContainerNames) && IsPrimaryContainerName(nameParts[1],PrimaryContainerNames) {
+				   if _,ok := LinkMap[containerName + "-" + nameParts[1]]; !ok {
+				    LinkMap[containerName + "-" + nameParts[1]] = "exists"
+				    buffer.WriteString(fmt.Sprintf(" \"%s\" -> \"%s\" [label = \" %s\" ]\n", containerName, nameParts[1], nameParts[len(nameParts)-1] ))
+				  }
+				}
 
 			}
 		}
@@ -144,12 +171,17 @@ func jsonContainersToDot(containers *[]Container) string {
 			containerBackground = "paleturquoise"
 		}
 
-		buffer.WriteString(fmt.Sprintf(" \"%s\" [label=\"%s\\n%s\",shape=box,fillcolor=\"%s\",style=\"filled,rounded\"];\n", containerName, containerName, truncate(container.Id, 12), containerBackground))
+		buffer.WriteString(fmt.Sprintf(" \"%s\" [label=\"%s\\n%s\\n%s\",shape=box,fillcolor=\"%s\",style=\"filled,rounded\"];\n", containerName, container.Image, containerName, truncate(container.Id, 12), containerBackground))
 	}
 
 	buffer.WriteString("}\n")
 
 	return buffer.String()
+}
+
+func IsPrimaryContainerName(Name string,PrimaryContainerNames map[string]string) bool {
+	_,ok := PrimaryContainerNames[Name]
+	return ok
 }
 
 func init() {

--- a/images.go
+++ b/images.go
@@ -468,7 +468,7 @@ func imagesToDot(buffer *bytes.Buffer, images []Image, byParent map[string][]Ima
 			// show partial command and size to make up for
 			// the fact that since Docker 1.10 content addressing
 			// image ids are usually empty and report as <missing>
-			SanitizedCommand := SanitizeCommand(image.CreatedBy,24)
+			SanitizedCommand := SanitizeCommand(image.CreatedBy,30)
 			buffer.WriteString(fmt.Sprintf(" \"%s\" [label=\"%s\"]\n", truncate(image.Id, 12), truncate(stripPrefix(image.OrigId), 12)+ "\n" + SanitizedCommand + "\n" + humanize.Bytes(uint64(image.Size)) ))
 		}
 		if subimages, exists := byParent[image.Id]; exists {
@@ -511,20 +511,25 @@ func jsonToShort(images *[]Image) string {
 func SanitizeCommand(CommandStr string,MaxLength int) string {
 
 	temp := CommandStr
+
+	// remove prefixes that don't add meaning
 	if(strings.HasPrefix(temp,"/bin/sh -c")) {
 	  temp = strings.TrimSpace(temp[10:])
 	}
 	if(strings.HasPrefix(temp,"#(nop)")) {
 	  temp = strings.TrimSpace(temp[6:])
 	}
-	temp = strings.Replace(temp,"\\"," ",-1)
+
+	// remove double and single quotes which make dot format invalid	
 	temp = strings.Replace(temp,"\""," ",-1)
 	temp = strings.Replace(temp,"'"," ",-1)
-	//temp = strings.Replace(temp,"[","(",-1)
-	//temp = strings.Replace(temp,"]",")",-1)
+
+	// remove double spaces inside
+	temp = strings.Join(strings.Fields(temp)," ")
 
 	return truncate(temp,MaxLength)
 }
+
 
 func init() {
 	parser.AddCommand("images",


### PR DESCRIPTION
**image.go changes**
Since docker 1.10 with content addressability, the image history image just shows <MISSING> in the picture, which makes it unidentifiable.  
https://stackoverflow.com/questions/35310212/docker-missing-layer-ids-in-output

I've added a truncation of the command and the size of the image layer to identify it
https://fabianlee.org/wp-content/uploads/2017/05/dockviz-images-whalesay.png

**container.go changes**
With docker now have multiple names per container, there are multiple dependency links shown between containers which are redundant and confusing.

I've added logic that uses only the primary link to link the containers, and also has an option to show only running containers.

https://fabianlee.org/wp-content/uploads/2017/05/dockviz-containers.png


**README.md**

Enhanced instructions on how to build binary using go and to explicitly use static linking with CGO_ENABLED so that the binary is statically linked.

**cli.go**

removed canonical import comment which causes error in build if project is forked.
